### PR TITLE
Added WKHTMLToPDF class with path to the binary to make usage even easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,16 @@ Also a symlink will be created in your configured bin/ folder, for example:
 
     vendor/bin/wkhtmltopdf-i386
 
+### Usage
+
+You can use the path constant to easily locate the binary in the PHP codebase: 
+
+``` php
+$path = \h4cc\WKHTMLToPDF\WKHTMLToPDF::PATH;
+```
+
+For realpath use following script
+
+``` php
+$realpath = realpath(\h4cc\WKHTMLToPDF\WKHTMLToPDF::PATH);
+```

--- a/WKHTMLToPDF.php
+++ b/WKHTMLToPDF.php
@@ -1,0 +1,7 @@
+<?php
+namespace h4cc\WKHTMLToPDF;
+
+class WKHTMLToPDF
+{
+    const PATH = __DIR__ . '/bin/wkhtmltopdf-amd64';
+}

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,10 @@
         "bin/wkhtmltopdf-amd64"
     ],
     "require": {
+    },
+    "autoload": {
+        "psr-4": {
+            "h4cc\\WKHTMLToPDF\\": ""
+        }
     }
 }


### PR DESCRIPTION
This adds new class WKHTMLToPDF that has path relative to the binary.

Some environment might have complex composer setting, moving dependencies around and it's hard to locate where the binary is. This makes it super easy, because anywhere from the code you can access the binary thanks to `\h4cc\WKHTMLToPDF\WKHTMLToPDF::PATH`.