### PR TITLE
Correct license information

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "h4cc/wkhtmltopdf-amd64",
     "description": "Convert html to pdf using webkit (qtwebkit). Static linked linux binary for amd64 systems.",
     "keywords": ["pdf", "thumbnail", "snapshot", "wkhtmltopdf", "convert", "binary"],
-    "license": "LGPL Version 3",
+    "license": "LGPL-3.0-only",
     "homepage": "http://wkhtmltopdf.org/",
     "authors": [
         {


### PR DESCRIPTION
Correct the license information in the composer.json file regarding to the official schema (https://getcomposer.org/doc/04-schema.md#license)